### PR TITLE
Pagination

### DIFF
--- a/api-examples/Get CVEs by Gardenlinux Version.bru
+++ b/api-examples/Get CVEs by Gardenlinux Version.bru
@@ -5,11 +5,13 @@ meta {
 }
 
 get {
-  url: {{schema_hostname_port}}/v1/cves/1592.0?sortBy=cveId
+  url: {{schema_hostname_port}}/v1/cves/1592.0?sortBy=cveId&pageNumber=1&pageSize=3
   body: none
   auth: none
 }
 
 params:query {
   sortBy: cveId
+  pageNumber: 1
+  pageSize: 3
 }

--- a/src/main/java/io/gardenlinux/glvd/GlvdController.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdController.java
@@ -33,8 +33,14 @@ public class GlvdController {
 
     @GetMapping("/cves/{gardenlinuxVersion}/packages/{packageList}")
     ResponseEntity<List<SourcePackageCve>> getCvePackages(
-            @PathVariable final String gardenlinuxVersion, @PathVariable final String packageList) {
-        var cveForPackages = glvdService.getCveForPackages(gardenlinuxVersion, packageList);
+            @PathVariable final String gardenlinuxVersion,
+            @PathVariable final String packageList,
+            @RequestParam(defaultValue = "cveId") final String sortBy,
+            @RequestParam(defaultValue = "ASC") final String sortOrder,
+            @RequestParam(required = false) final String pageNumber,
+            @RequestParam(required = false) final String pageSize
+    ) {
+        var cveForPackages = glvdService.getCveForPackages(gardenlinuxVersion, packageList, new SortAndPageOptions(sortBy, sortOrder, pageNumber, pageSize));
         return ResponseEntity.ok().body(cveForPackages);
     }
 

--- a/src/main/java/io/gardenlinux/glvd/GlvdController.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdController.java
@@ -24,9 +24,11 @@ public class GlvdController {
     ResponseEntity<List<SourcePackageCve>> getCveDistro(
             @PathVariable final String gardenlinuxVersion,
             @RequestParam(defaultValue = "cveId") final String sortBy,
-            @RequestParam(defaultValue = "ASC") final String sortOrder
+            @RequestParam(defaultValue = "ASC") final String sortOrder,
+            @RequestParam(required = false) final String pageNumber,
+            @RequestParam(required = false) final String pageSize
     ) {
-        return ResponseEntity.ok().body(glvdService.getCveForDistribution(gardenlinuxVersion, sortBy, sortOrder));
+        return ResponseEntity.ok().body(glvdService.getCveForDistribution(gardenlinuxVersion, new SortAndPageOptions(sortBy, sortOrder, pageNumber, pageSize)));
     }
 
     @GetMapping("/cves/{gardenlinuxVersion}/packages/{packageList}")
@@ -40,27 +42,34 @@ public class GlvdController {
     ResponseEntity<List<SourcePackageCve>> packageWithVulnerabilities(
             @PathVariable final String sourcePackage,
             @RequestParam(defaultValue = "cveId") final String sortBy,
-            @RequestParam(defaultValue = "ASC") final String sortOrder
+            @RequestParam(defaultValue = "ASC") final String sortOrder,
+            @RequestParam(required = false) final String pageNumber,
+            @RequestParam(required = false) final String pageSize
     ) {
-        return ResponseEntity.ok(glvdService.getPackageWithVulnerabilities(sourcePackage, sortBy, sortOrder));
+        return ResponseEntity.ok(glvdService.getPackageWithVulnerabilities(sourcePackage, new SortAndPageOptions(sortBy, sortOrder, pageNumber, pageSize)));
     }
 
     @GetMapping("/packages/{sourcePackage}/{sourcePackageVersion}")
     ResponseEntity<List<SourcePackageCve>> packageWithVulnerabilitiesByVersion(
             @PathVariable final String sourcePackage,
             @PathVariable final String sourcePackageVersion,
-            @RequestParam(defaultValue = "cveId") final String sortBy
+            @RequestParam(defaultValue = "cveId") final String sortBy,
+            @RequestParam(defaultValue = "ASC") final String sortOrder,
+            @RequestParam(required = false) final String pageNumber,
+            @RequestParam(required = false) final String pageSize
     ) {
-        return ResponseEntity.ok(glvdService.getPackageWithVulnerabilitiesByVersion(sourcePackage, sourcePackageVersion, sortBy));
+        return ResponseEntity.ok(glvdService.getPackageWithVulnerabilitiesByVersion(sourcePackage, sourcePackageVersion, new SortAndPageOptions(sortBy, sortOrder, pageNumber, pageSize)));
     }
 
     @GetMapping("/distro/{gardenlinuxVersion}")
     ResponseEntity<List<SourcePackage>> packagesForDistro(
             @PathVariable final String gardenlinuxVersion,
             @RequestParam(defaultValue = "sourcePackageName") final String sortBy,
-            @RequestParam(defaultValue = "ASC") final String sortOrder
+            @RequestParam(defaultValue = "ASC") final String sortOrder,
+            @RequestParam(required = false) final String pageNumber,
+            @RequestParam(required = false) final String pageSize
     ) {
-        return ResponseEntity.ok(glvdService.getPackagesForDistro(gardenlinuxVersion, sortBy, sortOrder));
+        return ResponseEntity.ok(glvdService.getPackagesForDistro(gardenlinuxVersion, new SortAndPageOptions(sortBy, sortOrder, pageNumber, pageSize)));
     }
 
     @GetMapping("/distro/{gardenlinuxVersion}/{cveId}")
@@ -68,9 +77,11 @@ public class GlvdController {
             @PathVariable final String gardenlinuxVersion,
             @PathVariable final String cveId,
             @RequestParam(defaultValue = "cveId") final String sortBy,
-            @RequestParam(defaultValue = "ASC") final String sortOrder
+            @RequestParam(defaultValue = "ASC") final String sortOrder,
+            @RequestParam(required = false) final String pageNumber,
+            @RequestParam(required = false) final String pageSize
     ) {
-        return ResponseEntity.ok(glvdService.getPackagesByVulnerability(gardenlinuxVersion, cveId, sortBy, sortOrder));
+        return ResponseEntity.ok(glvdService.getPackagesByVulnerability(gardenlinuxVersion, cveId, new SortAndPageOptions(sortBy, sortOrder, pageNumber, pageSize)));
     }
 
 }

--- a/src/main/java/io/gardenlinux/glvd/GlvdService.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdService.java
@@ -1,7 +1,15 @@
 package io.gardenlinux.glvd;
 
-import io.gardenlinux.glvd.db.*;
+import io.gardenlinux.glvd.db.SourcePackage;
+import io.gardenlinux.glvd.db.SourcePackageCve;
+import io.gardenlinux.glvd.db.SourcePackageCveRepository;
+import io.gardenlinux.glvd.db.SourcePackageRepository;
 import jakarta.annotation.Nonnull;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -16,33 +24,51 @@ public class GlvdService {
     @Nonnull
     private final SourcePackageRepository sourcePackageRepository;
 
+    Logger logger = LoggerFactory.getLogger(GlvdService.class);
+
     public GlvdService(@Nonnull SourcePackageCveRepository sourcePackageCveRepository, @Nonnull SourcePackageRepository sourcePackageRepository) {
         this.sourcePackageCveRepository = sourcePackageCveRepository;
         this.sourcePackageRepository = sourcePackageRepository;
     }
 
-    public List<SourcePackageCve> getCveForDistribution(String gardenlinuxVersion, String sortBy, String sortOrder) {
-        return sourcePackageCveRepository.findByGardenlinuxVersion(gardenlinuxVersion, Sort.by(Sort.Direction.valueOf(sortOrder), sortBy));
+    private Pageable determinePageAndSortFeatures(SortAndPageOptions sortAndPageOptions) {
+        var sort = Sort.by(Sort.Direction.valueOf(sortAndPageOptions.sortOrder()), sortAndPageOptions.sortBy());
+        if (!StringUtils.isEmpty(sortAndPageOptions.pageNumber()) && !StringUtils.isEmpty(sortAndPageOptions.pageSize())) {
+            try {
+                var num = Integer.parseInt(sortAndPageOptions.pageNumber());
+                var size = Integer.parseInt(sortAndPageOptions.pageSize());
+                return PageRequest.of(num, size, sort);
+            } catch (NumberFormatException e) {
+                // fall through, don't page
+                logger.warn("Could not parse paging parameters", e);
+            }
+        }
+
+        return Pageable.unpaged(sort);
+    }
+
+    public List<SourcePackageCve> getCveForDistribution(String gardenlinuxVersion, SortAndPageOptions sortAndPageOptions) {
+        return sourcePackageCveRepository.findByGardenlinuxVersion(gardenlinuxVersion, determinePageAndSortFeatures(sortAndPageOptions));
     }
 
     public List<SourcePackageCve> getCveForPackages(String gardenlinuxVersion, String packages) {
-        return sourcePackageCveRepository.findBySourcePackageNameInAndGardenlinuxVersion("{"+packages+"}", gardenlinuxVersion);
+        return sourcePackageCveRepository.findBySourcePackageNameInAndGardenlinuxVersion("{" + packages + "}", gardenlinuxVersion);
     }
 
-    public List<SourcePackage> getPackagesForDistro(String gardenlinuxVersion, String sortBy, String sortOrder) {
-        return sourcePackageRepository.findByGardenlinuxVersion(gardenlinuxVersion, Sort.by(Sort.Direction.valueOf(sortOrder), sortBy));
+    public List<SourcePackage> getPackagesForDistro(String gardenlinuxVersion, SortAndPageOptions sortAndPageOptions) {
+        return sourcePackageRepository.findByGardenlinuxVersion(gardenlinuxVersion, determinePageAndSortFeatures(sortAndPageOptions));
     }
 
-    public List<SourcePackageCve> getPackageWithVulnerabilities(String sourcePackage, String sortBy, String sortOrder) {
-        return sourcePackageCveRepository.findBySourcePackageName(sourcePackage, Sort.by(Sort.Direction.valueOf(sortOrder), sortBy));
+    public List<SourcePackageCve> getPackageWithVulnerabilities(String sourcePackage, SortAndPageOptions sortAndPageOptions) {
+        return sourcePackageCveRepository.findBySourcePackageName(sourcePackage, determinePageAndSortFeatures(sortAndPageOptions));
     }
 
-    public List<SourcePackageCve> getPackageWithVulnerabilitiesByVersion(String sourcePackage, String sourcePackageVersion, String sortBy) {
-        return sourcePackageCveRepository.findBySourcePackageNameAndSourcePackageVersion(sourcePackage, sourcePackageVersion, Sort.by(Sort.Direction.DESC, sortBy));
+    public List<SourcePackageCve> getPackageWithVulnerabilitiesByVersion(String sourcePackage, String sourcePackageVersion, SortAndPageOptions sortAndPageOptions) {
+        return sourcePackageCveRepository.findBySourcePackageNameAndSourcePackageVersion(sourcePackage, sourcePackageVersion, determinePageAndSortFeatures(sortAndPageOptions));
     }
 
-    public List<SourcePackageCve> getPackagesByVulnerability(String gardenlinuxVersion, String cveId, String sortBy, String sortOrder) {
-        return sourcePackageCveRepository.findByCveIdAndGardenlinuxVersion(cveId, gardenlinuxVersion, Sort.by(Sort.Direction.valueOf(sortOrder), sortBy));
+    public List<SourcePackageCve> getPackagesByVulnerability(String gardenlinuxVersion, String cveId, SortAndPageOptions sortAndPageOptions) {
+        return sourcePackageCveRepository.findByCveIdAndGardenlinuxVersion(cveId, gardenlinuxVersion, determinePageAndSortFeatures(sortAndPageOptions));
     }
 
 }

--- a/src/main/java/io/gardenlinux/glvd/GlvdService.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdService.java
@@ -47,12 +47,28 @@ public class GlvdService {
         return Pageable.unpaged(sort);
     }
 
+    // native query does not support sorting
+    private Pageable determinePageAndSortFeatures2(SortAndPageOptions sortAndPageOptions) {
+        if (!StringUtils.isEmpty(sortAndPageOptions.pageNumber()) && !StringUtils.isEmpty(sortAndPageOptions.pageSize())) {
+            try {
+                var num = Integer.parseInt(sortAndPageOptions.pageNumber());
+                var size = Integer.parseInt(sortAndPageOptions.pageSize());
+                return PageRequest.of(num, size);
+            } catch (NumberFormatException e) {
+                // fall through, don't page
+                logger.warn("Could not parse paging parameters", e);
+            }
+        }
+
+        return Pageable.unpaged();
+    }
+
     public List<SourcePackageCve> getCveForDistribution(String gardenlinuxVersion, SortAndPageOptions sortAndPageOptions) {
         return sourcePackageCveRepository.findByGardenlinuxVersion(gardenlinuxVersion, determinePageAndSortFeatures(sortAndPageOptions));
     }
 
     public List<SourcePackageCve> getCveForPackages(String gardenlinuxVersion, String packages, SortAndPageOptions sortAndPageOptions) {
-        return sourcePackageCveRepository.findBySourcePackageNameInAndGardenlinuxVersion("{" + packages + "}", gardenlinuxVersion, determinePageAndSortFeatures(sortAndPageOptions));
+        return sourcePackageCveRepository.findBySourcePackageNameInAndGardenlinuxVersion("{" + packages + "}", gardenlinuxVersion, determinePageAndSortFeatures2(sortAndPageOptions));
     }
 
     public List<SourcePackage> getPackagesForDistro(String gardenlinuxVersion, SortAndPageOptions sortAndPageOptions) {

--- a/src/main/java/io/gardenlinux/glvd/GlvdService.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdService.java
@@ -51,8 +51,8 @@ public class GlvdService {
         return sourcePackageCveRepository.findByGardenlinuxVersion(gardenlinuxVersion, determinePageAndSortFeatures(sortAndPageOptions));
     }
 
-    public List<SourcePackageCve> getCveForPackages(String gardenlinuxVersion, String packages) {
-        return sourcePackageCveRepository.findBySourcePackageNameInAndGardenlinuxVersion("{" + packages + "}", gardenlinuxVersion);
+    public List<SourcePackageCve> getCveForPackages(String gardenlinuxVersion, String packages, SortAndPageOptions sortAndPageOptions) {
+        return sourcePackageCveRepository.findBySourcePackageNameInAndGardenlinuxVersion("{" + packages + "}", gardenlinuxVersion, determinePageAndSortFeatures(sortAndPageOptions));
     }
 
     public List<SourcePackage> getPackagesForDistro(String gardenlinuxVersion, SortAndPageOptions sortAndPageOptions) {

--- a/src/main/java/io/gardenlinux/glvd/SortAndPageOptions.java
+++ b/src/main/java/io/gardenlinux/glvd/SortAndPageOptions.java
@@ -1,0 +1,4 @@
+package io.gardenlinux.glvd;
+
+public record SortAndPageOptions(String sortBy, String sortOrder, String pageNumber, String pageSize) {
+}

--- a/src/main/java/io/gardenlinux/glvd/UiController.java
+++ b/src/main/java/io/gardenlinux/glvd/UiController.java
@@ -49,9 +49,13 @@ public class UiController {
     public String getCveForPackages(
             @RequestParam(name = "gardenlinuxVersion", required = true) String gardenlinuxVersion,
             @RequestParam(name = "packages", required = true) String packages,
+            @RequestParam(defaultValue = "cveId") final String sortBy,
+            @RequestParam(defaultValue = "ASC") final String sortOrder,
+            @RequestParam(required = false) final String pageNumber,
+            @RequestParam(required = false) final String pageSize,
             Model model
     ) {
-        var sourcePackageCves = glvdService.getCveForPackages(gardenlinuxVersion, packages);
+        var sourcePackageCves = glvdService.getCveForPackages(gardenlinuxVersion, packages, new SortAndPageOptions(sortBy, sortOrder, pageNumber, pageSize));
         model.addAttribute("sourcePackageCves", sourcePackageCves);
         model.addAttribute("gardenlinuxVersion", gardenlinuxVersion);
         model.addAttribute("packages", packages);

--- a/src/main/java/io/gardenlinux/glvd/UiController.java
+++ b/src/main/java/io/gardenlinux/glvd/UiController.java
@@ -21,8 +21,10 @@ public class UiController {
             @RequestParam(name = "gardenlinuxVersion", required = true) String gardenlinuxVersion,
             @RequestParam(defaultValue = "cveId") final String sortBy,
             @RequestParam(defaultValue = "ASC") final String sortOrder,
+            @RequestParam(required = false) final String pageNumber,
+            @RequestParam(required = false) final String pageSize,
             Model model) {
-        var packages = glvdService.getPackagesForDistro(gardenlinuxVersion, sortBy, sortOrder);
+        var packages = glvdService.getPackagesForDistro(gardenlinuxVersion, new SortAndPageOptions(sortBy, sortOrder, pageNumber, pageSize));
         model.addAttribute("packages", packages);
         model.addAttribute("gardenlinuxVersion", gardenlinuxVersion);
         return "getPackagesForDistro";
@@ -33,9 +35,11 @@ public class UiController {
             @RequestParam(name = "gardenlinuxVersion", required = true) String gardenlinuxVersion,
             @RequestParam(defaultValue = "cveId") final String sortBy,
             @RequestParam(defaultValue = "ASC") final String sortOrder,
+            @RequestParam(required = false) final String pageNumber,
+            @RequestParam(required = false) final String pageSize,
             Model model
     ) {
-        var sourcePackageCves = glvdService.getCveForDistribution(gardenlinuxVersion, sortBy, sortOrder);
+        var sourcePackageCves = glvdService.getCveForDistribution(gardenlinuxVersion, new SortAndPageOptions(sortBy, sortOrder, pageNumber, pageSize));
         model.addAttribute("sourcePackageCves", sourcePackageCves);
         model.addAttribute("gardenlinuxVersion", gardenlinuxVersion);
         return "getCveForDistribution";
@@ -60,9 +64,11 @@ public class UiController {
             @RequestParam(name = "cveId", required = true) String cveId,
             @RequestParam(defaultValue = "cveId") final String sortBy,
             @RequestParam(defaultValue = "ASC") final String sortOrder,
+            @RequestParam(required = false) final String pageNumber,
+            @RequestParam(required = false) final String pageSize,
             Model model
     ) {
-        var sourcePackageCves = glvdService.getPackagesByVulnerability(gardenlinuxVersion, cveId, sortBy, sortOrder);
+        var sourcePackageCves = glvdService.getPackagesByVulnerability(gardenlinuxVersion, cveId, new SortAndPageOptions(sortBy, sortOrder, pageNumber, pageSize));
         model.addAttribute("sourcePackageCves", sourcePackageCves);
         model.addAttribute("gardenlinuxVersion", gardenlinuxVersion);
         model.addAttribute("cveId", cveId);

--- a/src/main/java/io/gardenlinux/glvd/db/SourcePackageCveRepository.java
+++ b/src/main/java/io/gardenlinux/glvd/db/SourcePackageCveRepository.java
@@ -19,9 +19,10 @@ public interface SourcePackageCveRepository extends JpaRepository<SourcePackageC
     // would be nice if we did not need a native query here
     // is this (the in-array search for packages) possible in any other way with spring data jpa?
     // fixme: does not support sorting, cf https://github.com/spring-projects/spring-data-jpa/issues/2504#issuecomment-1527743003
+    // pagination seems to work ok
     @Query(value = """
     SELECT * FROM sourcepackagecve
     WHERE source_package_name = ANY(:source_package_names ::TEXT[]) AND gardenlinux_version = :gardenlinux_version
     """, nativeQuery = true)
-    List<SourcePackageCve> findBySourcePackageNameInAndGardenlinuxVersion(@Param("source_package_names") String source_package_names, @Param("gardenlinux_version") String gardenlinux_version);
+    List<SourcePackageCve> findBySourcePackageNameInAndGardenlinuxVersion(@Param("source_package_names") String source_package_names, @Param("gardenlinux_version") String gardenlinux_version, Pageable pageable);
 }

--- a/src/main/java/io/gardenlinux/glvd/db/SourcePackageCveRepository.java
+++ b/src/main/java/io/gardenlinux/glvd/db/SourcePackageCveRepository.java
@@ -10,11 +10,11 @@ import java.util.List;
 
 public interface SourcePackageCveRepository extends JpaRepository<SourcePackageCve, String> {
 
-    List<SourcePackageCve> findBySourcePackageName(@Param("source_package_name") String source_package_name, Sort sort);
-    List<SourcePackageCve> findBySourcePackageNameAndSourcePackageVersion(@Param("source_package_name") String source_package_name, @Param("source_package_version") String source_package_version, Sort sort);
-    List<SourcePackageCve> findByCveIdAndGardenlinuxVersion(@Param("cve_id") String cve_id, @Param("gardenlinux_version") String gardenlinux_version, Sort sort);
+    List<SourcePackageCve> findBySourcePackageName(@Param("source_package_name") String source_package_name, Pageable pageable);
+    List<SourcePackageCve> findBySourcePackageNameAndSourcePackageVersion(@Param("source_package_name") String source_package_name, @Param("source_package_version") String source_package_version, Pageable pageable);
+    List<SourcePackageCve> findByCveIdAndGardenlinuxVersion(@Param("cve_id") String cve_id, @Param("gardenlinux_version") String gardenlinux_version, Pageable pageable);
 
-    List<SourcePackageCve> findByGardenlinuxVersion(@Param("gardenlinux_version") String gardenlinux_version, Sort sort);
+    List<SourcePackageCve> findByGardenlinuxVersion(@Param("gardenlinux_version") String gardenlinux_version, Pageable pageable);
 
     // would be nice if we did not need a native query here
     // is this (the in-array search for packages) possible in any other way with spring data jpa?

--- a/src/main/java/io/gardenlinux/glvd/db/SourcePackageRepository.java
+++ b/src/main/java/io/gardenlinux/glvd/db/SourcePackageRepository.java
@@ -1,5 +1,6 @@
 package io.gardenlinux.glvd.db;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
@@ -7,5 +8,5 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface SourcePackageRepository extends JpaRepository<SourcePackage, String> {
-    List<SourcePackage> findByGardenlinuxVersion(@Param("gardenlinux_version") String gardenlinux_version, Sort by);
+    List<SourcePackage> findByGardenlinuxVersion(@Param("gardenlinux_version") String gardenlinux_version, Pageable pageable);
 }

--- a/src/test/java/io/gardenlinux/glvd/GlvdControllerTest.java
+++ b/src/test/java/io/gardenlinux/glvd/GlvdControllerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -79,7 +78,7 @@ class GlvdControllerTest {
                 .filter(document("getCveForDistro",
                         preprocessRequest(modifyUris().scheme("https").host("glvd.gardenlinux.io").removePort()),
                         preprocessResponse(prettyPrint())))
-                .when().port(this.port).get("/v1/cves/1592.0?sortBy=cveId&sortOrder=DESC")
+                .when().port(this.port).get("/v1/cves/1592.0?sortBy=cveId&sortOrder=DESC&pageNumber=4&pageSize=2")
 				.then().statusCode(HttpStatus.SC_OK);
     }
 
@@ -89,7 +88,7 @@ class GlvdControllerTest {
                 .filter(document("getCveForPackages",
                         preprocessRequest(modifyUris().scheme("https").host("glvd.gardenlinux.io").removePort()),
                         preprocessResponse(prettyPrint())))
-                .when().port(this.port).get("/v1/cves/1592.0/packages/crun,vim")
+                .when().port(this.port).get("/v1/cves/1592.0/packages/crun,vim?pageNumber=4&pageSize=2")
                 .then().statusCode(HttpStatus.SC_OK);
     }
 
@@ -99,7 +98,7 @@ class GlvdControllerTest {
                 .filter(document("getPackages",
                         preprocessRequest(modifyUris().scheme("https").host("glvd.gardenlinux.io").removePort()),
                         preprocessResponse(prettyPrint())))
-                .when().port(this.port).get("/v1/distro/1592.0")
+                .when().port(this.port).get("/v1/distro/1592.0?pageNumber=4&pageSize=2")
                 .then().statusCode(200);
     }
 
@@ -109,7 +108,7 @@ class GlvdControllerTest {
                 .filter(document("getPackageWithVulnerabilities",
                         preprocessRequest(modifyUris().scheme("https").host("glvd.gardenlinux.io").removePort()),
                         preprocessResponse(prettyPrint())))
-                .when().port(this.port).get("/v1/packages/vim")
+                .when().port(this.port).get("/v1/packages/vim?pageNumber=4&pageSize=2")
                 .then().statusCode(200);
     }
 
@@ -119,7 +118,7 @@ class GlvdControllerTest {
                 .filter(document("getPackageWithVulnerabilitiesByVersion",
                         preprocessRequest(modifyUris().scheme("https").host("glvd.gardenlinux.io").removePort()),
                         preprocessResponse(prettyPrint())))
-                .when().port(this.port).get("/v1/packages/vim/2:9.1.0496-1+b1")
+                .when().port(this.port).get("/v1/packages/vim/2:9.1.0496-1+b1?pageNumber=4&pageSize=2")
                 .then().statusCode(200);
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for (optional) pagination in the http api

Combined with sorting this allows clients to only get the data they want and save bandwidth and processing time.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/glvd/issues/98
