### PR TITLE
Add base_score property to SourcePackageCve

### DIFF
--- a/src/main/java/io/gardenlinux/glvd/db/SourcePackageCve.java
+++ b/src/main/java/io/gardenlinux/glvd/db/SourcePackageCve.java
@@ -16,6 +16,9 @@ public class SourcePackageCve {
     @Column(name = "base_score", nullable = true)
     private float baseScore;
 
+    @Column(name = "vector_string", nullable = true)
+    private String vectorString;
+
     @Column(name = "source_package_name", nullable = false)
     private String sourcePackageName;
 
@@ -34,9 +37,10 @@ public class SourcePackageCve {
     public SourcePackageCve() {
     }
 
-    public SourcePackageCve(String cveId, float baseScore, String sourcePackageName, String sourcePackageVersion, String gardenlinuxVersion, boolean isVulnerable, String cvePublishedDate) {
+    public SourcePackageCve(String cveId, float baseScore, String vectorString, String sourcePackageName, String sourcePackageVersion, String gardenlinuxVersion, boolean isVulnerable, String cvePublishedDate) {
         this.cveId = cveId;
         this.baseScore = baseScore;
+        this.vectorString = vectorString;
         this.sourcePackageName = sourcePackageName;
         this.sourcePackageVersion = sourcePackageVersion;
         this.gardenlinuxVersion = gardenlinuxVersion;
@@ -70,5 +74,9 @@ public class SourcePackageCve {
 
     public String getCvePublishedDate() {
         return cvePublishedDate;
+    }
+
+    public String getVectorString() {
+        return vectorString;
     }
 }

--- a/src/main/java/io/gardenlinux/glvd/db/SourcePackageCve.java
+++ b/src/main/java/io/gardenlinux/glvd/db/SourcePackageCve.java
@@ -13,6 +13,9 @@ public class SourcePackageCve {
     @Column(name = "cve_id", nullable = false)
     private String cveId;
 
+    @Column(name = "base_score", nullable = true)
+    private float baseScore;
+
     @Column(name = "source_package_name", nullable = false)
     private String sourcePackageName;
 
@@ -31,8 +34,9 @@ public class SourcePackageCve {
     public SourcePackageCve() {
     }
 
-    public SourcePackageCve(String cveId, @Nonnull String sourcePackageName, @Nonnull String sourcePackageVersion, @Nonnull String gardenlinuxVersion, boolean isVulnerable, @Nonnull String cvePublishedDate) {
+    public SourcePackageCve(String cveId, float baseScore, String sourcePackageName, String sourcePackageVersion, String gardenlinuxVersion, boolean isVulnerable, String cvePublishedDate) {
         this.cveId = cveId;
+        this.baseScore = baseScore;
         this.sourcePackageName = sourcePackageName;
         this.sourcePackageVersion = sourcePackageVersion;
         this.gardenlinuxVersion = gardenlinuxVersion;
@@ -44,17 +48,18 @@ public class SourcePackageCve {
         return cveId;
     }
 
-    @Nonnull
+    public float getBaseScore() {
+        return baseScore;
+    }
+
     public String getSourcePackageName() {
         return sourcePackageName;
     }
 
-    @Nonnull
     public String getSourcePackageVersion() {
         return sourcePackageVersion;
     }
 
-    @Nonnull
     public String getGardenlinuxVersion() {
         return gardenlinuxVersion;
     }
@@ -63,7 +68,6 @@ public class SourcePackageCve {
         return isVulnerable;
     }
 
-    @Nonnull
     public String getCvePublishedDate() {
         return cvePublishedDate;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Base score is relevant to triage cve issues

**Which issue(s) this PR fixes**:
Fixes [#glvd/100](https://github.com/gardenlinux/glvd/issues/100)
