### PR TITLE
View CVE context in a table

### DIFF
--- a/src/main/resources/templates/getCveDetails.html
+++ b/src/main/resources/templates/getCveDetails.html
@@ -57,13 +57,27 @@
 
 <h2>CVE Context</h2>
 
-<!-- FIXME not yet clear how this information is properly displayed as we have have many entries for each cve.. for now just dump the info here. -->
-<div th:each="context: ${cveContexts}">
-    <p th:text="${context.description}"/>
-    <p th:text="${context.createDate}"/>
-    <p th:text="${context.getResolved}"/>
-    <p th:text="${context.scoreOverride}"/>
-</div>
+<table>
+    <thead>
+    <tr>
+        <th>Date</th>
+        <th>Dist ID</th>
+        <th>Descriptor</th>
+        <th>Is Resolved?</th>
+        <th>Score Override</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr th:each="context: ${cveContexts}">
+        <td th:text="${context.createDate}"/>
+        <td th:text="${context.distId}"/>
+        <td th:text="${context.contextDescriptor}"/>
+        <td th:text="${context.getResolved}"/>
+        <td th:text="${context.scoreOverride}"/>
+        <td th:text="${context.description}"/>
+    </tr>
+
+</table>
 
 </body>
 </html>


### PR DESCRIPTION
Show more information from CVE contexts. A table is not ideal here for descriptions, need to find a better way to present that information in the long term, but this should work for now.