### PR TITLE
Display NVD exclusive CVEs in GLVD

### DIFF
--- a/src/main/java/io/gardenlinux/glvd/GlvdService.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdService.java
@@ -30,15 +30,18 @@ public class GlvdService {
     @Nonnull
     private final DistCpeRepository distCpeRepository;
 
+    @Nonnull
+    private final NvdExclusiveCveRepository nvdExclusiveCveRepository;
 
     Logger logger = LoggerFactory.getLogger(GlvdService.class);
 
-    public GlvdService(@Nonnull SourcePackageCveRepository sourcePackageCveRepository, @Nonnull SourcePackageRepository sourcePackageRepository, @Nonnull CveDetailsRepository cveDetailsRepository, @Nonnull CveContextRepository cveContextRepository, @Nonnull DistCpeRepository distCpeRepository) {
+    public GlvdService(@Nonnull SourcePackageCveRepository sourcePackageCveRepository, @Nonnull SourcePackageRepository sourcePackageRepository, @Nonnull CveDetailsRepository cveDetailsRepository, @Nonnull CveContextRepository cveContextRepository, @Nonnull DistCpeRepository distCpeRepository, @Nonnull NvdExclusiveCveRepository nvdExclusiveCveRepository) {
         this.sourcePackageCveRepository = sourcePackageCveRepository;
         this.sourcePackageRepository = sourcePackageRepository;
         this.cveDetailsRepository = cveDetailsRepository;
         this.cveContextRepository = cveContextRepository;
         this.distCpeRepository = distCpeRepository;
+        this.nvdExclusiveCveRepository = nvdExclusiveCveRepository;
     }
 
     private Pageable determinePageAndSortFeatures(SortAndPageOptions sortAndPageOptions) {
@@ -127,5 +130,9 @@ public class GlvdService {
 
     public String distVersionToId(String version) {
         return distCpeRepository.getByCpeVersion(version).getId();
+    }
+
+    public Iterable<NvdExclusiveCve> getAllNvdExclusiveCve() {
+        return nvdExclusiveCveRepository.findAll();
     }
 }

--- a/src/main/java/io/gardenlinux/glvd/UiController.java
+++ b/src/main/java/io/gardenlinux/glvd/UiController.java
@@ -122,7 +122,7 @@ public class UiController {
         return "getCveDetails";
     }
 
-    @GetMapping("getNvdExclusiveCve")
+    @GetMapping("/getNvdExclusiveCve")
     public String getNvdExclusiveCve(Model model) {
         var cves = glvdService.getAllNvdExclusiveCve();
         model.addAttribute("cves", cves);

--- a/src/main/java/io/gardenlinux/glvd/UiController.java
+++ b/src/main/java/io/gardenlinux/glvd/UiController.java
@@ -122,4 +122,11 @@ public class UiController {
         return "getCveDetails";
     }
 
+    @GetMapping("getNvdExclusiveCve")
+    public String getNvdExclusiveCve(Model model) {
+        var cves = glvdService.getAllNvdExclusiveCve();
+        model.addAttribute("cves", cves);
+        return "getNvdExclusiveCve";
+    }
+
 }

--- a/src/main/java/io/gardenlinux/glvd/db/NvdExclusiveCve.java
+++ b/src/main/java/io/gardenlinux/glvd/db/NvdExclusiveCve.java
@@ -6,20 +6,52 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "nvd_exclusive_cve")
+@Table(name = "nvd_exclusive_cve_matching_gl")
 public class NvdExclusiveCve {
     @Id
     @Column(name = "cve_id", nullable = false)
     private String cveId;
 
+    @Column(name = "vulnstatus", nullable = false)
+    private String vulnStatus;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "published", nullable = false)
+    private String cvePublishedDate;
+
+    @Column(name = "modified", nullable = false)
+    private String cveModifiedDate;
+
     public NvdExclusiveCve() {
     }
 
-    public NvdExclusiveCve(String cveId) {
+    public NvdExclusiveCve(String cveId, String vulnStatus, String description, String cvePublishedDate, String cveModifiedDate) {
         this.cveId = cveId;
+        this.vulnStatus = vulnStatus;
+        this.description = description;
+        this.cvePublishedDate = cvePublishedDate;
+        this.cveModifiedDate = cveModifiedDate;
     }
 
     public String getCveId() {
         return cveId;
+    }
+
+    public String getVulnStatus() {
+        return vulnStatus;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getCvePublishedDate() {
+        return cvePublishedDate;
+    }
+
+    public String getCveModifiedDate() {
+        return cveModifiedDate;
     }
 }

--- a/src/main/java/io/gardenlinux/glvd/db/NvdExclusiveCve.java
+++ b/src/main/java/io/gardenlinux/glvd/db/NvdExclusiveCve.java
@@ -1,0 +1,25 @@
+package io.gardenlinux.glvd.db;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "nvd_exclusive_cve")
+public class NvdExclusiveCve {
+    @Id
+    @Column(name = "cve_id", nullable = false)
+    private String cveId;
+
+    public NvdExclusiveCve() {
+    }
+
+    public NvdExclusiveCve(String cveId) {
+        this.cveId = cveId;
+    }
+
+    public String getCveId() {
+        return cveId;
+    }
+}

--- a/src/main/java/io/gardenlinux/glvd/db/NvdExclusiveCveRepository.java
+++ b/src/main/java/io/gardenlinux/glvd/db/NvdExclusiveCveRepository.java
@@ -1,0 +1,6 @@
+package io.gardenlinux.glvd.db;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface NvdExclusiveCveRepository extends CrudRepository<NvdExclusiveCve, String> {
+}

--- a/src/main/resources/templates/getCveForDistribution.html
+++ b/src/main/resources/templates/getCveForDistribution.html
@@ -16,6 +16,10 @@
 
 <a th:href="@{/getCveForDistribution(gardenlinuxVersion=1592.5,onlyVulnerable=true)}">1592.5</a>
 
+<div>
+    <a th:href="@{/getNvdExclusiveCve}">NVD Exclusive CVEs (need to triage)</a>
+</div>
+
 <p th:text="|Found ${#lists.size(sourcePackageCves)} potential security issues|"></p>
 
 <a th:href="@{/getCveForDistributionAll(gardenlinuxVersion=${gardenlinuxVersion},onlyVulnerable=false)}">Show all potential issues</a>

--- a/src/main/resources/templates/getCveForDistributionAll.html
+++ b/src/main/resources/templates/getCveForDistributionAll.html
@@ -16,6 +16,10 @@
 
 <a th:href="@{/getCveForDistributionAll(gardenlinuxVersion=1592.5,onlyVulnerable=false)}">1592.5</a>
 
+<div>
+    <a th:href="@{/getNvdExclusiveCve}">NVD Exclusive CVEs (need to triage)</a>
+</div>
+
 <p th:text="|Found ${#lists.size(sourcePackageCves)} potential security issues|"></p>
 
 <a th:href="@{/getCveForDistribution(gardenlinuxVersion=${gardenlinuxVersion},onlyVulnerable=true)}">Show only unresolved potential issues</a>

--- a/src/main/resources/templates/getNvdExclusiveCve.html
+++ b/src/main/resources/templates/getNvdExclusiveCve.html
@@ -7,18 +7,23 @@
 </head>
 <body>
 
-<table>
-    <thead>
-    <tr>
-        <th>CVE ID
-        </th>
-    </tr>
-    </thead>
+<h1>NVD Exclusive CVEs</h1>
 
-    <tr th:each="item: ${cves}">
-        <td><a th:href="@{/getCveDetails(cveId=${item.cveId})}"> <div th:text="${item.cveId}"></div> </a></td>
-    </tr>
-</table>
+<div>
+    The following list contains recent CVEs which are not in debian's security tracker (yet).
+    There is a good chance that those don't affect Garden Linux at all, but some of them might.
+    They are shown here to get a chance to react as quickly as possible, in case any of them is relevant.
+</div>
+
+<ul>
+    <li th:each="item: ${cves}">
+        <a th:href="@{/getCveDetails(cveId=${item.cveId})}"> <div th:text="${item.cveId}"></div> </a>
+        Vulnerability Status: <div th:text="${item.vulnStatus}"></div>
+        CVE Published Date: <div th:text="${item.cvePublishedDate}"></div>
+        CVE Modified Date: <div th:text="${item.cveModifiedDate}"></div>
+        Description: <label th:text="${item.description}"></label>
+    </li>
+</ul>
 
 </body>
 </html>

--- a/src/main/resources/templates/getNvdExclusiveCve.html
+++ b/src/main/resources/templates/getNvdExclusiveCve.html
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>GLVD: List CVE only available in NVD</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <link href="style.css" rel="stylesheet" media="screen" />
+</head>
+<body>
+
+<table>
+    <thead>
+    <tr>
+        <th>CVE ID
+        </th>
+    </tr>
+    </thead>
+
+    <tr th:each="item: ${cves}">
+        <td><a th:href="@{/getCveDetails(cveId=${item.cveId})}"> <div th:text="${item.cveId}"></div> </a></td>
+    </tr>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
Show CVEs which are not (yet) in debian's security tracker to allow quick response.
Note that by design this has a relatively high probability of false positives.

Fixes https://github.com/gardenlinux/glvd/issues/140

