### PR TITLE
Make ci workflow more easy to work with forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,11 @@ jobs:
     needs:
       - build
     env:
-      IMAGE_NAME: gardenlinux/glvd-api
+      # Change this if you fork the repo
+      IMAGE_NAME_ORG: gardenlinux
+      # Change this if you fork the repo
+      OIDC_AUDIENCE: glvd
+      IMAGE_NAME: glvd-api
       IMAGE_TAG: latest
 
     steps:
@@ -91,7 +95,7 @@ jobs:
         id: build_image
         uses: redhat-actions/buildah-build@v2
         with:
-          image: ${{ env.IMAGE_NAME }}
+          image: ${{ env.IMAGE_NAME_ORG }}/${{ env.IMAGE_NAME }}
           tags: ${{ env.IMAGE_TAG }}
           platforms: linux/amd64, linux/arm64
           containerfiles: |
@@ -131,14 +135,14 @@ jobs:
 
       - name: Build bare images
         run: |
-          ./build_bare.sh
+          ./build_bare.sh ghcr.io/${{ env.IMAGE_NAME_ORG }}/${{ env.IMAGE_NAME }} latest
 
       - name: Push bare images
         if: ${{ github.event_name != 'pull_request' }}
         id: bare
         run: |
-          podman push --digestfile=bare-amd64-digest ghcr.io/gardenlinux/glvd-api:latest-linuxamd64_bare
-          podman push ghcr.io/gardenlinux/glvd-api:latest-linuxarm64_bare
+          podman push --digestfile=bare-amd64-digest ghcr.io/${{ env.IMAGE_NAME_ORG }}/${{ env.IMAGE_NAME }}:latest-linuxamd64_bare
+          podman push ghcr.io/${{ env.IMAGE_NAME_ORG }}/${{ env.IMAGE_NAME }}:latest-linuxarm64_bare
           echo "bare-amd64-digest=$(cat ./bare-amd64-digest)" >> $GITHUB_OUTPUT
 
       - name: Print image url
@@ -153,7 +157,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         id: get-token
         run: |
-          IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=glvd" | jq -r '.value')
+          IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ env.OIDC_AUDIENCE }}" | jq -r '.value')
           echo "idToken=${IDTOKEN}" >> $GITHUB_OUTPUT
 
       - uses: azure/k8s-set-context@v4
@@ -164,7 +168,7 @@ jobs:
 
       - name: Deploy the image
         if: ${{ github.event_name != 'pull_request' }}
-        run: kubectl --namespace default --token "${{ steps.get-token.outputs.idToken }}" set image deploy/glvd glvd-api=ghcr.io/gardenlinux/glvd-api:latest-linuxamd64_bare@${{ steps.bare.outputs.bare-amd64-digest }}
+        run: kubectl --namespace default --token "${{ steps.get-token.outputs.idToken }}" set image deploy/glvd glvd-api=ghcr.io/${{ env.IMAGE_NAME_ORG }}/${{ env.IMAGE_NAME }}:latest-linuxamd64_bare@${{ steps.bare.outputs.bare-amd64-digest }}
 
   dependency-submission:
 

--- a/build_bare.sh
+++ b/build_bare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-GLVD_API_IMAGE_REPOSITORY=ghcr.io/gardenlinux/glvd-api
-GLVD_API_IMAGE_TAG=latest
+GLVD_API_IMAGE_REPOSITORY=${1:-ghcr.io/gardenlinux/glvd-api}
+GLVD_API_IMAGE_TAG=${2:-latest}
 
 build () {
     local ARCH="${1}"; shift


### PR DESCRIPTION
This makes it easier to fork the repo and setup ci for another repo.

Useful for testing https://github.com/gardenlinux/security/issues/114