### PR TITLE
Implement needed endpoints for triage process

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,6 +11,16 @@ This document describes the HTTP API endpoints of Garden Linux Vulnerability Dat
 
 CAUTION: This document and the API are work in progress and subject to change at any time.
 
+=== Get all known Garden Linux Releases
+
+To query all known Garden Linux releases, you may use this endpoint:
+
+include::{snippets}/getAllGardenLinuxVersions/curl-request.adoc[]
+
+The expected response looks like this:
+
+include::{snippets}/getAllGardenLinuxVersions/http-response.adoc[]
+
 === Get a list of CVEs by distro
 
 To query all CVEs for a given distribution by version, you may use this endpoint:

--- a/src/main/java/io/gardenlinux/glvd/GlvdController.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdController.java
@@ -120,6 +120,23 @@ public class GlvdController {
         );
     }
 
+    // Internal API, undocumented on purpose
+    // This is needed for the triage implementation
+    // No external consumers should use this endpoint
+    @GetMapping(value = "/distro/{gardenlinuxVersion}/distId", produces = "text/plain")
+    ResponseEntity<String> distIdForDistro(
+            @PathVariable final String gardenlinuxVersion
+    ) {
+        return ResponseEntity.ok(
+                glvdService.distVersionToId(gardenlinuxVersion)
+        );
+    }
+
+    @GetMapping("/gardenlinuxVersions")
+    ResponseEntity<List<String>> getAllDistros() {
+        return ResponseEntity.ok(glvdService.allGardenLinuxVersions());
+    }
+
     @GetMapping("/cveDetails/{cveId}")
     ResponseEntity<CveDetailsWithContext> cveDetails(@PathVariable final String cveId) {
         var cveDetails = glvdService.getCveDetails(cveId);

--- a/src/main/java/io/gardenlinux/glvd/GlvdService.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdService.java
@@ -186,6 +186,16 @@ public class GlvdService {
         return distCpeRepository.getByCpeVersion(version).getId();
     }
 
+    public List<String> allGardenLinuxVersions() {
+        return distCpeRepository.findAll().stream()
+                .filter(distCpe -> distCpe.getCpeProduct().equalsIgnoreCase("gardenlinux"))
+                .map(DistCpe::getCpeVersion)
+                .filter(StringUtils::isNotBlank)
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
     public Iterable<NvdExclusiveCve> getAllNvdExclusiveCve() {
         return nvdExclusiveCveRepository.findAll();
     }

--- a/src/test/java/io/gardenlinux/glvd/GlvdControllerTest.java
+++ b/src/test/java/io/gardenlinux/glvd/GlvdControllerTest.java
@@ -51,9 +51,6 @@ class GlvdControllerTest {
     @Test
     public void shouldReturnCvesForGardenlinuxShouldNotReturnKernelCveMarkedAsResolved() {
         given(this.spec).accept("application/json")
-                .filter(document("getCveForDistro",
-                        preprocessRequest(modifyUris().scheme("https").host("glvd.ingress.glvd.gardnlinux.shoot.canary.k8s-hana.ondemand.com").removePort()),
-                        preprocessResponse(prettyPrint())))
                 .when().port(this.port).get("/v1/cves/1592.5?sortBy=cveId&sortOrder=DESC")
                 .then().statusCode(HttpStatus.SC_OK)
                 .body("cveId", hasItems("CVE-2025-0938", "CVE-2025-21864", "CVE-2024-44953"))
@@ -64,9 +61,6 @@ class GlvdControllerTest {
     @Test
     public void shuldReturnKernelCvesForGardenLinuxByPackageNameAndMarkResolvedCveAsNotVulnerable() {
         given(this.spec).accept("application/json")
-                .filter(document("getCveForDistro",
-                        preprocessRequest(modifyUris().scheme("https").host("glvd.ingress.glvd.gardnlinux.shoot.canary.k8s-hana.ondemand.com").removePort()),
-                        preprocessResponse(prettyPrint())))
                 .when().port(this.port).get("/v1/cves/1592.5/packages/linux")
                 .then().statusCode(HttpStatus.SC_OK)
                 .body("cveId", hasItems("CVE-2025-21864", "CVE-2024-44953"))
@@ -77,9 +71,6 @@ class GlvdControllerTest {
     @Test
     public void shuldReturnKernelCvesForGardenLinuxByPackageName() {
         given(this.spec).accept("application/json")
-                .filter(document("getCveForDistro",
-                        preprocessRequest(modifyUris().scheme("https").host("glvd.ingress.glvd.gardnlinux.shoot.canary.k8s-hana.ondemand.com").removePort()),
-                        preprocessResponse(prettyPrint())))
                 .when().port(this.port).get("/v1/cves/1592.6/packages/linux")
                 .then().statusCode(HttpStatus.SC_OK)
                 .body("cveId", hasItems("CVE-2025-21864", "CVE-2024-44953"))
@@ -305,6 +296,25 @@ class GlvdControllerTest {
                 .when().port(this.port).get("/v1/triage/1592.8")
                 .then().statusCode(200)
                 .body("", empty());
+    }
+
+    @Test
+    public void shouldResolveGardenLinuxVersionToDistId() {
+        given(this.spec).accept("text/plain")
+                .when().port(this.port).get("/v1/distro/1592.10/distId")
+                .then().statusCode(200)
+                .body(equalTo("24"));
+    }
+
+    @Test
+    public void shouldGetAllGardenLinuxVersions() {
+        given(this.spec).accept("application/json")
+                .filter(document("getAllGardenLinuxVersions",
+                        preprocessRequest(modifyUris().scheme("https").host("glvd.ingress.glvd.gardnlinux.shoot.canary.k8s-hana.ondemand.com").removePort()),
+                        preprocessResponse(prettyPrint())))
+                .when().port(this.port).get("/v1/gardenlinuxVersions")
+                .then().statusCode(200)
+                .body("$", hasItems("1592.4", "1592.5", "1592.6", "1592.7", "1592.8", "1592.9", "1592.10", "today"));
     }
 
 }


### PR DESCRIPTION
Add API endpoints for listing all known GL versions and to convert the GL version into the internal dist id.

Needed for https://github.com/gardenlinux/glvd/issues/157