### PR TITLE
fix: Always return empty releaseNotes endpoint response

### DIFF
--- a/src/main/java/io/gardenlinux/glvd/GlvdService.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdService.java
@@ -282,41 +282,15 @@ public class GlvdService {
 
     // keep this method to provide the old api
     public ReleaseNote releaseNoteTwoDigitVersion(final String gardenlinuxVersion) {
-        if (gardenlinuxVersion.endsWith(".0")) {
-            return new ReleaseNote(gardenlinuxVersion, List.of());
-        }
-        var v = new TwoDigitGardenLinuxVersion(gardenlinuxVersion);
-
-        var packagesNew = sourcePackagesByGardenLinuxVersion(v.printVersion());
-
-        // We get an empty list if the new version is not yet present in glvd which creates a useless diff
-        // This should not happen in a normal release process because the 'new' version should be ingested into glvd when we get here
-        if (packagesNew.isEmpty()) {
-            return new ReleaseNote(gardenlinuxVersion, List.of());
-        }
-
-        var cvesOldVersion = getCveForDistribution(v.previousPatchVersion(), new SortAndPageOptions("cveId", "ASC", null, null));
-        var cvesNewVersion = getCveForDistribution(v.printVersion(), new SortAndPageOptions("cveId", "ASC", null, null));
-        var resolvedInNew = getCveContextsForDist(distVersionToId(gardenlinuxVersion)).stream().filter(CveContext::getResolved).map(CveContext::getCveId).toList();
-        var packagesOld = sourcePackagesByGardenLinuxVersion(v.previousPatchVersion());
-
-        return new ReleaseNoteGenerator(v, cvesOldVersion, cvesNewVersion, resolvedInNew, packagesOld, packagesNew).generate();
+        // do not provide a result for now
+        // Release page is too big for github and a lot of false-positives which require manual clean up
+        return new ReleaseNote(gardenlinuxVersion, List.of());
     }
 
     private ReleaseNote releaseNoteThreeDigitVersion(final String gardenlinuxVersion) {
-        if (gardenlinuxVersion.endsWith(".0.0")) {
-            return new ReleaseNote(gardenlinuxVersion, List.of());
-        }
-        var v = new ThreeDigitGardenLinuxVersion(gardenlinuxVersion);
-        var packagesNew = sourcePackagesByGardenLinuxVersion(v.printVersion());
-        if (packagesNew.isEmpty()) {
-            return new ReleaseNote(gardenlinuxVersion, List.of());
-        }
-        var cvesOldVersion = getCveForDistribution(v.previousMinorVersion(), new SortAndPageOptions("cveId", "ASC", null, null));
-        var cvesNewVersion = getCveForDistribution(v.printVersion(), new SortAndPageOptions("cveId", "ASC", null, null));
-        var resolvedInNew = getCveContextsForDist(distVersionToId(gardenlinuxVersion)).stream().filter(CveContext::getResolved).map(CveContext::getCveId).toList();
-        var packagesOld = sourcePackagesByGardenLinuxVersion(v.previousMinorVersion());
-        return new ReleaseNoteGenerator(v, cvesOldVersion, cvesNewVersion, resolvedInNew, packagesOld, packagesNew).generate();
+        // do not provide a result for now
+        // Release page is too big for github and a lot of false-positives which require manual clean up
+        return new ReleaseNote(gardenlinuxVersion, List.of());
     }
 
     private static List<Triage> filterNonUserRelevantTriages(List<Triage> input) {

--- a/src/test/java/io/gardenlinux/glvd/GlvdControllerTest.java
+++ b/src/test/java/io/gardenlinux/glvd/GlvdControllerTest.java
@@ -282,8 +282,6 @@ class GlvdControllerTest {
         this.mockMvc.perform(get("/v1/releaseNotes/2000.1.0"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.version", is("2000.1.0")))
-                .andExpect(jsonPath("$.packageList[0].sourcePackageName", is("util-linux")))
-                .andExpect(jsonPath("$.packageList[0].fixedCves", hasItems("CVE-2022-0563")))
                 .andDo(doc("releaseNotes"));
     }
 
@@ -308,15 +306,6 @@ class GlvdControllerTest {
         this.mockMvc.perform(get("/v1/patchReleaseNotes/1592.5"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.version", is("1592.5")))
-                .andExpect(jsonPath("$.packageList[0].sourcePackageName", is(oneOf("jinja2", "rsync", "curl", "python3.12"))))
-                .andExpect(jsonPath("$.packageList[*].fixedCves[*]", hasItems(
-                        "CVE-2024-56326",
-                        "CVE-2024-12085",
-                        "CVE-2024-12086",
-                        "CVE-2024-11053",
-                        "CVE-2024-9287",
-                        "CVE-2025-0938"
-                )))
                 .andDo(doc("patchReleaseNotes"));
     }
 
@@ -325,8 +314,6 @@ class GlvdControllerTest {
         this.mockMvc.perform(get("/v1/patchReleaseNotes/1592.7"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.version", is("1592.7")))
-                .andExpect(jsonPath("$.packageList[0].sourcePackageName", is("linux")))
-                .andExpect(jsonPath("$.packageList[0].fixedCves", contains("CVE-2025-21864")))
                 .andDo(doc("patchReleaseNotesResolved"));
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Quick fix now to avoid issues with too large release pages for the Github API. Also the previous response required a manual clean up anyway, so avoid publishing these false-positives, which could be picked up by external parties like VAS.