### PR TITLE
Add second manual release page endpoint

### DIFF
--- a/src/main/java/io/gardenlinux/glvd/GlvdController.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdController.java
@@ -178,8 +178,21 @@ public class GlvdController {
         return glvdService.releaseNoteTwoDigitVersion(gardenlinuxVersion);
     }
 
+    // used by the release process to generate the Github release page
     @GetMapping("/releaseNotes/{gardenlinuxVersion}")
     ResponseEntity<ReleaseNote> releaseNotes(@PathVariable final String gardenlinuxVersion) {
+        try {
+            // do not provide a result for now
+            // Release page is too big for github and a lot of false-positives which require manual clean up
+            return ResponseEntity.ok(glvdService.emptyReleaseNote(gardenlinuxVersion));
+        } catch (InvalidGardenLinuxVersionException invalidGardenLinuxVersionException) {
+            return ResponseEntity.badRequest().header("Message", invalidGardenLinuxVersionException.getMessage()).build();
+        }
+    }
+
+    // allows to get the release output manually even though the previous endpoint now returns an empty list all the times
+    @GetMapping("/releaseNotesManual/{gardenlinuxVersion}")
+    ResponseEntity<ReleaseNote> releaseNotesManual(@PathVariable final String gardenlinuxVersion) {
         try {
             return ResponseEntity.ok(glvdService.releaseNote(gardenlinuxVersion));
         } catch (InvalidGardenLinuxVersionException invalidGardenLinuxVersionException) {

--- a/src/main/java/io/gardenlinux/glvd/GlvdService.java
+++ b/src/main/java/io/gardenlinux/glvd/GlvdService.java
@@ -270,6 +270,14 @@ public class GlvdService {
         return debSrcRepository.findByDistId(Integer.parseInt(distVersionToId(version)));
     }
 
+    public ReleaseNote emptyReleaseNote(final String gardenlinuxVersion) {
+        if (!gardenlinuxVersion.matches(THREE_DIGIT_VERSION_SCHEMA) && !gardenlinuxVersion.matches(TWO_DIGIT_VERSION_SCHEMA)) {
+            throw new InvalidGardenLinuxVersionException("gardenlinuxVersion must be in n.n or n.n.n format, but was: " + gardenlinuxVersion);
+        }
+
+        return new ReleaseNote(gardenlinuxVersion, List.of());
+    }
+
     public ReleaseNote releaseNote(final String gardenlinuxVersion) {
         if (gardenlinuxVersion.matches(THREE_DIGIT_VERSION_SCHEMA)) {
             return releaseNoteThreeDigitVersion(gardenlinuxVersion);
@@ -282,15 +290,41 @@ public class GlvdService {
 
     // keep this method to provide the old api
     public ReleaseNote releaseNoteTwoDigitVersion(final String gardenlinuxVersion) {
-        // do not provide a result for now
-        // Release page is too big for github and a lot of false-positives which require manual clean up
-        return new ReleaseNote(gardenlinuxVersion, List.of());
+        if (gardenlinuxVersion.endsWith(".0")) {
+            return new ReleaseNote(gardenlinuxVersion, List.of());
+        }
+        var v = new TwoDigitGardenLinuxVersion(gardenlinuxVersion);
+
+        var packagesNew = sourcePackagesByGardenLinuxVersion(v.printVersion());
+
+        // We get an empty list if the new version is not yet present in glvd which creates a useless diff
+        // This should not happen in a normal release process because the 'new' version should be ingested into glvd when we get here
+        if (packagesNew.isEmpty()) {
+            return new ReleaseNote(gardenlinuxVersion, List.of());
+        }
+
+        var cvesOldVersion = getCveForDistribution(v.previousPatchVersion(), new SortAndPageOptions("cveId", "ASC", null, null));
+        var cvesNewVersion = getCveForDistribution(v.printVersion(), new SortAndPageOptions("cveId", "ASC", null, null));
+        var resolvedInNew = getCveContextsForDist(distVersionToId(gardenlinuxVersion)).stream().filter(CveContext::getResolved).map(CveContext::getCveId).toList();
+        var packagesOld = sourcePackagesByGardenLinuxVersion(v.previousPatchVersion());
+
+        return new ReleaseNoteGenerator(v, cvesOldVersion, cvesNewVersion, resolvedInNew, packagesOld, packagesNew).generate();
     }
 
     private ReleaseNote releaseNoteThreeDigitVersion(final String gardenlinuxVersion) {
-        // do not provide a result for now
-        // Release page is too big for github and a lot of false-positives which require manual clean up
-        return new ReleaseNote(gardenlinuxVersion, List.of());
+        if (gardenlinuxVersion.endsWith(".0.0")) {
+            return new ReleaseNote(gardenlinuxVersion, List.of());
+        }
+        var v = new ThreeDigitGardenLinuxVersion(gardenlinuxVersion);
+        var packagesNew = sourcePackagesByGardenLinuxVersion(v.printVersion());
+        if (packagesNew.isEmpty()) {
+            return new ReleaseNote(gardenlinuxVersion, List.of());
+        }
+        var cvesOldVersion = getCveForDistribution(v.previousMinorVersion(), new SortAndPageOptions("cveId", "ASC", null, null));
+        var cvesNewVersion = getCveForDistribution(v.printVersion(), new SortAndPageOptions("cveId", "ASC", null, null));
+        var resolvedInNew = getCveContextsForDist(distVersionToId(gardenlinuxVersion)).stream().filter(CveContext::getResolved).map(CveContext::getCveId).toList();
+        var packagesOld = sourcePackagesByGardenLinuxVersion(v.previousMinorVersion());
+        return new ReleaseNoteGenerator(v, cvesOldVersion, cvesNewVersion, resolvedInNew, packagesOld, packagesNew).generate();
     }
 
     private static List<Triage> filterNonUserRelevantTriages(List<Triage> input) {


### PR DESCRIPTION
The quick fix of returning an empty list of CVEs for the pipeline is still active, but add a second endpoint that allows to get actual output before the fix.

Helps in the meantime with the manual creation of the CVE list.