### PR TITLE
fix: Hard-code 1877.17 as previous version of 1877.19

### DIFF
--- a/src/main/java/io/gardenlinux/glvd/version/TwoDigitGardenLinuxVersion.java
+++ b/src/main/java/io/gardenlinux/glvd/version/TwoDigitGardenLinuxVersion.java
@@ -17,6 +17,9 @@ public class TwoDigitGardenLinuxVersion implements GardenLinuxVersion {
     }
 
     public String previousPatchVersion() {
+        if(major == 1877 && patch == 19) {
+            return "1877.17";
+        }
         return major + "." + (patch - 1);
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Needed as a quick fix to get release notes for 1877.19.